### PR TITLE
Ensure even padding in chat input

### DIFF
--- a/app/playground/ChatClient.tsx
+++ b/app/playground/ChatClient.tsx
@@ -290,7 +290,7 @@ function ChatInput({ value, onValueChange, onSend, isSubmitting, files, onFileUp
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
             placeholder="Ask anything"
-            className="min-h-[44px] pt-3 pl-4 text-base leading-[1.3] sm:text-base md:text-base"
+            className="min-h-[44px] pt-3 px-4 text-base leading-[1.3] sm:text-base md:text-base"
           />
           <PromptInputActions className="mt-3 w-full justify-between p-2">
             <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- add symmetric horizontal padding to chat textarea for balanced spacing

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b67d14baec83209c565e58e88ca882