### PR TITLE
Fix user and ai text color mismatch

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -143,7 +143,7 @@ a:hover { opacity: 0.9; }
 }
 
 .prose-message {
-  @apply w-full;
+  @apply w-full text-neutral-800 dark:text-neutral-200;
   max-width: 100% !important;
   width: 100% !important;
   display: block;


### PR DESCRIPTION
Update `.prose-message` to apply `text-neutral-800 dark:text-neutral-200` to ensure user and AI chat text colors match.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6d38ac7-c02d-4ab3-a51a-32032ff935a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a6d38ac7-c02d-4ab3-a51a-32032ff935a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

