### PR TITLE
Align user label color with assistant label

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -257,6 +257,7 @@ a:hover { opacity: 0.9; }
 /* Tighter spacing for explicit chat labels placed before content blocks */
 .prose-message .chat-label {
   margin-top: 0 !important;
+  @apply text-neutral-800 dark:text-neutral-200;
 }
 
 pre::-webkit-scrollbar {

--- a/app/playground/ChatClient.tsx
+++ b/app/playground/ChatClient.tsx
@@ -574,7 +574,7 @@ export default function ChatClient() {
               if (isParagraph) {
                 const withLabel = rawHtml.replace(
                   /<p(.*?)>/,
-                  `<p$1><span class="font-bold mr-1">${speaker}:</span>`
+                  `<p$1><span class="font-bold mr-1 text-neutral-800 dark:text-neutral-200">${speaker}:</span>`
                 )
                 return (
                   <div
@@ -586,7 +586,7 @@ export default function ChatClient() {
               }
               return (
                 <div key={`block-${i}`} className="prose-message font-sans">
-                  <div className="chat-label font-bold mb-1">{speaker}:</div>
+                  <div className="chat-label font-bold mb-1 text-neutral-800 dark:text-neutral-200">{speaker}:</div>
                   <div dangerouslySetInnerHTML={{ __html: sanitizeHtml(rawHtml) }} />
                 </div>
               )


### PR DESCRIPTION
## Summary
- ensure user chat labels use the same text color as assistant labels
- style chat-label elements in CSS to inherit the standard message color

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7d27ebd50832097a7179a1e50689d